### PR TITLE
fix: add missing members to IPlugin structs

### DIFF
--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -229,7 +229,7 @@ interface IPlugin {
     function postExecutionHook(uint8 functionId, bytes calldata preExecHookData) external;
 
     /// @notice Describe the contents and intended configuration of the plugin.
-    /// @dev This function MUST NOT make any state changes.
+    /// @dev The manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the plugin.
     function pluginManifest() external pure returns (PluginManifest memory);
 }
@@ -279,6 +279,7 @@ struct ManifestExecutionHook {
 }
 
 struct ManifestStandardExecutionHook {
+    bytes4 executionSelector;
     ManifestFunction validator;
     ManifestFunction preExecHook;
     ManifestFunction postExecHook;
@@ -318,6 +319,7 @@ struct PluginManifest {
     ManifestPreValidationHook[] preUserOpValidationHooks;
     ManifestPreValidationHook[] preRuntimeValidationHooks;
     ManifestExecutionHook[] executionHooks;
+    ManifestExecutionHook[] pluginExecutionHooks;
     ManifestStandardExecutionHook[] standardExecutionHooks;
 }
 ```


### PR DESCRIPTION
In the next update, it's probably worth expanding on the different "hook types" ("global", validator-associated for standard execution, and plugin-associated for executeFromPlugin).